### PR TITLE
Refactor parameter names from 'object' to 'obj'

### DIFF
--- a/src/Common/ThrowHelper.ts
+++ b/src/Common/ThrowHelper.ts
@@ -21,42 +21,42 @@ export namespace ThrowHelper
 			}
 		}
 
-		export function throwIfNullable<T>(object: T): asserts object is NonNullable<T>
+		export function throwIfNullable<T>(obj: T): asserts obj is NonNullable<T>
 		{
-			if (TypeHelper.isNullable(object))
+			if (TypeHelper.isNullable(obj))
 			{
 				throw new TypeErrorConstructor("Object is nullable");
 			}
 		}
 
-		export function throwIfNotNullable<T>(object: T): asserts object is Extract<T, null | undefined>
+		export function throwIfNotNullable<T>(obj: T): asserts obj is Extract<T, null | undefined>
 		{
-			if (!TypeHelper.isNullable(object))
+			if (!TypeHelper.isNullable(obj))
 			{
 				throw new TypeErrorConstructor("Object is not nullable");
 			}
 		}
 
-		export function throwIfUndefined<T>(object: T): asserts object is Extract<T, undefined>
+		export function throwIfUndefined<T>(obj: T): asserts obj is Extract<T, undefined>
 		{
-			if (object === undefined)
+			if (obj === undefined)
 			{
 				throw new TypeErrorConstructor("Object is undefined");
 			}
 		}
 
-		export function throwIfType<TObject, TType extends TypeResolvable>(object: TObject, type: TType)
-			: asserts object is Exclude<TObject, ResolvedType<TType>>
+		export function throwIfType<TObject, TType extends TypeResolvable>(obj: TObject, type: TType)
+			: asserts obj is Exclude<TObject, ResolvedType<TType>>
 		{
-			if (TypeHelper.isType(object, type))
+			if (TypeHelper.isType(obj, type))
 			{
 				throw new TypeErrorConstructor("Object cannot be an instance of the specified type");
 			}
 		}
 
-		export function throwIfNotType<T extends TypeResolvable>(object: unknown, type: T): asserts object is ResolvedType<T>
+		export function throwIfNotType<T extends TypeResolvable>(obj: unknown, type: T): asserts obj is ResolvedType<T>
 		{
-			if (!TypeHelper.isType(object, type))
+			if (!TypeHelper.isType(obj, type))
 			{
 				throw new TypeErrorConstructor("Object is not an instance of the type expected");
 			}
@@ -65,18 +65,18 @@ export namespace ThrowHelper
 		export function throwIfNotAnyType<
 			T1 extends TypeResolvable,
 			T2 extends TypeResolvable,
-			T3 extends TypeResolvable>(object: unknown, type1: T1, type2: T2, type3?: T3)
-			: asserts object is ResolvedType<T1> | ResolvedType<T2> | ResolvedType<T3>
+			T3 extends TypeResolvable>(obj: unknown, type1: T1, type2: T2, type3?: T3)
+			: asserts obj is ResolvedType<T1> | ResolvedType<T2> | ResolvedType<T3>
 		{
-			if (!TypeHelper.isAnyType(object, type1, type2, type3))
+			if (!TypeHelper.isAnyType(obj, type1, type2, type3))
 			{
 				throw new TypeErrorConstructor("Object is not an instance of the type expected");
 			}
 		}
 
-		export function throwIfNotTypeArray<T extends TypeResolvable>(object: unknown, type: T): asserts object is ResolvedType<T>[]
+		export function throwIfNotTypeArray<T extends TypeResolvable>(obj: unknown, type: T): asserts obj is ResolvedType<T>[]
 		{
-			if (!TypeHelper.isTypeArray(object, type))
+			if (!TypeHelper.isTypeArray(obj, type))
 			{
 				throw new TypeErrorConstructor("Object is not an array or an item is of an unexpected type");
 			}
@@ -85,9 +85,9 @@ export namespace ThrowHelper
 
 	export namespace ReferenceError
 	{
-		export function throwIfUndefined<T>(object: T): asserts object is Exclude<T, undefined>
+		export function throwIfUndefined<T>(obj: T): asserts obj is Exclude<T, undefined>
 		{
-			if (object === undefined)
+			if (obj === undefined)
 			{
 				throw new ReferenceErrorConstructor("Value is undefined");
 			}

--- a/src/Common/TypeHelper.ts
+++ b/src/Common/TypeHelper.ts
@@ -1,39 +1,39 @@
 ﻿export namespace TypeHelper
 {
-	export function isNullable<T>(object: T): object is Extract<T, null | undefined>
+	export function isNullable<T>(obj: T): obj is Extract<T, null | undefined>
 	{
-		return object === null || object === undefined;
+		return obj === null || obj === undefined;
 	}
 
-	export function isType<T extends TypeResolvable>(object: unknown, type: T): object is ResolvedType<T>
+	export function isType<T extends TypeResolvable>(obj: unknown, type: T): obj is ResolvedType<T>
 	{
 		if (typeof type === "string")
 		{
 			return (
 				// Check whether typeof of the object is the same as the type string.
-				typeof object === type ||
+				typeof obj === type ||
 
 				// Check if object is null for type "null"
-				(type === "null" && object === null) ||
+				(type === "null" && obj === null) ||
 
 				// Check if object is either null or undefined for type "nullable"
-				(type === "nullable" && isNullable(object)) ||
+				(type === "nullable" && isNullable(obj)) ||
 
 				// Check if object is iterable for type "iterable"
-				(type === "iterable" && (object as any)[Symbol.iterator] !== undefined) ||
+				(type === "iterable" && (obj as any)[Symbol.iterator] !== undefined) ||
 
 				// Check if object is array for type "array"
-				(type === "array" && Array.isArray(object))
+				(type === "array" && Array.isArray(obj))
 			);
 		}
 
 		return (
 			// Check if the object is an instance of the specified class
-			(typeof type === "function" && object instanceof type) ||
+			(typeof type === "function" && obj instanceof type) ||
 
 			// For checking whether a numeric value is defined in the enum's members
 			// does not work as expected with flag enums
-			(typeof type === "object" && Object.values(type).includes(object as string | number))
+			(typeof type === "object" && Object.values(type).includes(obj as string | number))
 		);
 	}
 


### PR DESCRIPTION
Renamed function parameters from 'object' to 'obj' in ThrowHelper and TypeHelper to avoid shadowing the global 'Object' type and improve code clarity. No functional changes were made.